### PR TITLE
Add trailing slash to generated URL paths

### DIFF
--- a/lib/eventbrite/resources/user.rb
+++ b/lib/eventbrite/resources/user.rb
@@ -13,7 +13,7 @@ module Eventbrite
       private
 
       define_singleton_method "#{m}_url" do |user_id|
-        "/#{CGI.escape(class_name.downcase)}s/#{user_id}/#{m}"
+        "/#{CGI.escape(class_name.downcase)}s/#{user_id}/#{m}/"
       end
     end
   end


### PR DESCRIPTION
I'm seeing a lot of hits to `/v3/users/me/owned_events?status=live` in our (Eventbrite's) logs, which return a 301 redirect to `/v3/users/me/owned_events/?status=live`. This fix should ensure that requests don't get redirected and hence hit our API servers twice. The same fix may be needed in other places in the code as well (I don't have a Ruby test environment set up at the moment).
