### PR TITLE
Remove dependency on hashie

### DIFF
--- a/eventbrite.gemspec
+++ b/eventbrite.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rest-client", "~> 1.4"
-  spec.add_dependency "hashie", "~> 3.0"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "byebug"

--- a/lib/eventbrite.rb
+++ b/lib/eventbrite.rb
@@ -1,5 +1,4 @@
 require 'rest_client'
-require 'hashie'
 
 # Version
 require 'eventbrite/version'


### PR DESCRIPTION
Hashie is not used in this gem and caused some version conflicts when we attempted to install this gem in one of our apps.